### PR TITLE
Set default ENTRYPOINT, streamline image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM centos:7
 
-RUN yum install -y unzip wget
+RUN yum install -y unzip
 
 # Install bcl2fastq 2.18.0
-RUN wget http://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2-18-0-12-linux-x86-64.zip && \
-	unzip bcl2fastq2-v2-18-0-12-linux-x86-64.zip && \
-	rpm -i bcl2fastq2-v2.18.0.12-Linux-x86_64.rpm && \
-	rm bcl2fastq2-v2-18-0-12-linux-x86-64.zip && \
-	rm bcl2fastq2-v2.18.0.12-Linux-x86_64.rpm
 
+ADD http://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2-18-0-12-linux-x86-64.zip  /
 
+RUN unzip /bcl2fastq2-v2-18-0-12-linux-x86-64.zip && \
+	rpm -i /bcl2fastq2-v2.18.0.12-Linux-x86_64.rpm && \
+	rm /bcl2fastq2-v2-18-0-12-linux-x86-64.zip && \
+	rm /bcl2fastq2-v2.18.0.12-Linux-x86_64.rpm
+
+# Set default behavior to run the command and get help.
+ENTRYPOINT ["bcl2fastq"]
+CMD ["--help"]


### PR DESCRIPTION
This update doesn't need wget (uses the ADD in the Dockerfile instead)
Also, sets default behavior to run "bcl2fastq --help" when the container is started with no parameters.  